### PR TITLE
update hasura v2.30.0 and change grafana dashboard urls

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,35 @@
+The changelog is automatically generated using [git-chglog](https://github.com/git-chglog/git-chglog) and it follows [Keep a Changelog](https://keepachangelog.com) format.
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end -}}
+{{ end -}}
+
+{{- if .MergeCommits }}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ if .Versions }}
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,29 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/hasura/helm-charts
+options:
+  commits:
+    filters:
+      Type:
+        - Added
+        - Changed
+        - Deprecated
+        - Removed
+        - Fixed
+        - Security
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^((\\w+)\\s.*)$"
+    pattern_maps:
+      - Subject
+      - Type
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,6 +3,9 @@ name: Lint and Test Charts
 on:
   workflow_call:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   lint-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,25 +2,129 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - main
+    branches: ["release/*"]
 
 jobs:
   tests:
     uses: ./.github/workflows/lint-test.yaml
 
-  release:
+  find-charts-to-release:
+    runs-on: ubuntu-latest
+    needs: [tests]
+    outputs:
+      modified-charts-files: ${{ steps.list-changed-charts.outputs.all_modified_files }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get list of changed charts
+        id: list-changed-charts
+        uses: tj-actions/changed-files@v36
+        with:
+          files: charts/*/Chart.yaml
+
+  generate-charts-changelog:
+    needs: find-charts-to-release
+    if: needs.find-charts-to-release.outputs.modified-charts-files
+    runs-on: ubuntu-latest
+    container: quay.io/git-chglog/git-chglog:0.15.4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install main dependencies
+        run: |
+          apk add bash
+
+      - name: Generate charts changelog files
+        shell: bash
+        run: |
+          set -x
+          apk add git grep yq
+
+          # TODO: Bundle all of that logic in a Github Action to make it easy to share.
+          for chart_file in ${{ needs.find-charts-to-release.outputs.modified-charts-files }}; do
+              chart_name=$(grep -Po "(?<=^name: ).+" ${chart_file})
+              chart_version=$(grep -Po "(?<=^version: ).+" ${chart_file})
+              chart_tag="${chart_name}-${chart_version}"
+              chart_path="charts/${chart_name}"
+
+              #
+              # Generate chart CHANGELOG.md file.
+              git-chglog                                \
+                  --output "${chart_path}/CHANGELOG.md" \
+                  --tag-filter-pattern "${chart_name}"  \
+                  --next-tag "${chart_tag}"             \
+                  --path "${chart_path}"
+
+              #
+              # Generate RELEASE-NOTES.md file (used for Github release notes and ArtifactHub "changes" annotation).
+              git-chglog                                    \
+                  --output "${chart_path}/RELEASE-NOTES.md" \
+                  --tag-filter-pattern "${chart_name}"      \
+                  --next-tag "${chart_tag}"                 \
+                  --path "${chart_path}" "${chart_tag}"
+
+              #
+              # Update ArtifactHub "changes" annotation in the Chart.yaml file.
+              # https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
+              change_types="Added Changed Deprecated Removed Fixed Security"
+
+              # TODO: Rethink about this approach of using bash to generate YAML changes for ArtifactHub,
+              # and find out if there is a better/cleaner way to make it.
+              echo '|' > "${chart_path}/changes-for-artifacthub.yaml"
+              for change_type in ${change_types}; do
+                  change_type_section=$(sed -rn "/^\#+\s${change_type}/,/^(#|$)/p" "${chart_path}/RELEASE-NOTES.md")
+                  if [[ -n "${change_type_section}" ]]; then
+                      echo "${change_type_section}" | egrep '^-' | sed 's/^- //g' | while read commit_message; do
+                          echo "  - kind: ${change_type,,}"
+                          echo "    description: \"${commit_message}\""
+                      done >> "${chart_path}/changes-for-artifacthub.yaml"
+                  fi
+              done
+
+              cat "${chart_path}/changes-for-artifacthub.yaml"
+
+              # Merge changes back to the Chart.yaml file.
+              yq eval-all \
+                  'select(fileIndex==0).annotations."artifacthub.io/changes" = select(fileIndex==1) | select(fileIndex==0)' \
+                  ${chart_path}/Chart.yaml ${chart_path}/changes-for-artifacthub.yaml > \
+                  ${chart_path}/Chart-with-artifacthub-changes.yaml
+
+              mv ${chart_path}/Chart-with-artifacthub-changes.yaml ${chart_path}/Chart.yaml
+          done
+
+      - name: Stash generated charts changelog files
+        uses: actions/upload-artifact@v3
+        with:
+          name: charts-generated-changelog
+          path: |
+            charts/*/RELEASE-NOTES.md
+            charts/*/CHANGELOG.md
+            charts/*/Chart.yaml
+
+  release-charts:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
-    needs: [tests]
+    needs: generate-charts-changelog
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Unstash generated charts changelog files
+        uses: actions/download-artifact@v3
+        with:
+          name: charts-generated-changelog
+          path: charts
 
       - name: Configure Git
         run: |
@@ -40,3 +144,41 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  commit-charts-changelog:
+    needs:
+      - find-charts-to-release
+      - release-charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Unstash generated charts changelog files
+        uses: actions/download-artifact@v3
+        with:
+          name: charts-generated-changelog
+          path: charts
+
+      - name: Commit charts CHANGELOG.md file
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+          released_charts_files="${{ needs.find-charts-to-release.outputs.modified-charts-files }}"
+          echo "released_charts_files: ${released_charts_files}"
+
+          # Commit changes locally.
+          for chart_file in ${released_charts_files}; do
+              chart_name=$(grep -Po "(?<=^name: ).+" ${chart_file})
+              chart_version=$(grep -Po "(?<=^version: ).+" ${chart_file})
+              chart_path="charts/${chart_name}"
+
+              git add ${chart_path}/CHANGELOG.md
+              git commit -m "Update CHANGELOG for chart ${chart_name} ${chart_version}"
+          done
+
+          # Push changes to the main branch.
+          git push origin "${GITHUB_REF##*/}":main

--- a/charts/graphql-data-connector/Chart.yaml
+++ b/charts/graphql-data-connector/Chart.yaml
@@ -17,8 +17,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.29.0
+appVersion: 2.30.0

--- a/charts/graphql-data-connector/values.yaml
+++ b/charts/graphql-data-connector/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 ##
 image:
   repository: hasura/graphql-data-connector
-  tag: v2.29.0
+  tag: v2.30.0
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/charts/graphql-engine/Chart.lock
+++ b/charts/graphql-engine/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgres
   repository: file://../postgres
-  version: 0.0.1
-digest: sha256:2cd899d6775c9b727661153abb1d3460f55afaa7733903c95a6831751de9b836
-generated: "2023-07-20T14:56:21.729885372+07:00"
+  version: 0.1.0
+digest: sha256:3aeada8a389ee6ec186892a9820b3b930a89b042ba6a462eb5db4227b99bc082
+generated: "2023-07-21T16:47:06.808326551+07:00"

--- a/charts/graphql-engine/Chart.yaml
+++ b/charts/graphql-engine/Chart.yaml
@@ -17,14 +17,14 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.29.0
+appVersion: 2.30.0
 
 dependencies:
   - name: postgres
-    version: 0.0.1
+    version: 0.1.0
     repository: file://../postgres
     condition: postgres.enabled

--- a/charts/graphql-engine/values.yaml
+++ b/charts/graphql-engine/values.yaml
@@ -39,7 +39,7 @@ labels: {}
 ##
 image:
   repository: hasura/graphql-engine
-  tag: v2.29.0
+  tag: v2.30.0
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/charts/hasura-enterprise-stack/Chart.lock
+++ b/charts/hasura-enterprise-stack/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: graphql-engine
   repository: file://../graphql-engine
-  version: 0.0.1
+  version: 0.1.0
 - name: graphql-data-connector
   repository: file://../graphql-data-connector
-  version: 0.0.1
+  version: 0.1.0
 - name: mongo-data-connector
   repository: file://../mongo-data-connector
-  version: 0.0.1
+  version: 0.1.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.11.7
+  version: 17.13.2
 - name: dex
   repository: https://charts.dexidp.io
-  version: 0.14.3
+  version: 0.15.2
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 47.3.0
+  version: 48.1.2
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 0.71.8
-digest: sha256:edece22d24ad82734de57122e698b42dd0e584dc938d8ad66e45c928cf6f5a80
-generated: "2023-07-20T14:56:39.166529034+07:00"
+  version: 0.71.10
+digest: sha256:4259fa375f7717427a182da886254f96a1d10bac90aa43755478ae7dc148a52f
+generated: "2023-07-21T17:01:28.441443462+07:00"

--- a/charts/hasura-enterprise-stack/Chart.yaml
+++ b/charts/hasura-enterprise-stack/Chart.yaml
@@ -17,38 +17,38 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.29.0
+appVersion: 2.30.0
 
 dependencies:
   - name: graphql-engine
-    version: 0.0.1
+    version: 0.1.0
     repository: file://../graphql-engine
     condition: graphql-engine.enabled
   - name: graphql-data-connector
-    version: 0.0.1
+    version: 0.1.0
     repository: file://../graphql-data-connector
     condition: global.connector.graphql.enabled
   - name: mongo-data-connector
-    version: 0.0.1
+    version: 0.1.0
     repository: file://../mongo-data-connector
     condition: global.connector.mongo.enabled
   - name: redis
-    version: 17.11.7
+    version: 17.13.2
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: global.redis.enabled
   - name: dex
-    version: 0.14.3
+    version: 0.15.2
     repository: https://charts.dexidp.io
     condition: dex.enabled
   - name: kube-prometheus-stack
-    version: 47.3.0
+    version: 48.1.2
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled
   - name: jaeger
-    version: 0.71.8
+    version: 0.71.10
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled

--- a/charts/hasura-enterprise-stack/values.yaml
+++ b/charts/hasura-enterprise-stack/values.yaml
@@ -162,15 +162,15 @@ kube-prometheus-stack:
       ## Dashboards for Hasura Prometheus metrics
       hasura:
         hasura-overview:
-          url: https://raw.githubusercontent.com/hasura/ee-observability-demo/main/grafana/dashboards/hasura/hasura-overview.json
+          url: https://grafana.com/api/dashboards/19120/revisions/1/download
         hasura-graphql-http:
-          url: https://raw.githubusercontent.com/hasura/ee-observability-demo/main/grafana/dashboards/hasura/hasura-graphql-http.json
+          url: https://grafana.com/api/dashboards/19121/revisions/1/download
         hasura-health:
-          url: https://raw.githubusercontent.com/hasura/ee-observability-demo/main/grafana/dashboards/hasura/hasura-health.json
+          url: https://grafana.com/api/dashboards/19124/revisions/1/download
         hasura-subscription:
-          url: https://raw.githubusercontent.com/hasura/ee-observability-demo/main/grafana/dashboards/hasura/hasura-subscription.json
+          url: https://grafana.com/api/dashboards/19123/revisions/1/download
         hasura-events:
-          url: https://raw.githubusercontent.com/hasura/ee-observability-demo/main/grafana/dashboards/hasura/hasura-events.json
+          url: https://grafana.com/api/dashboards/19122/revisions/1/download
 
     ## Configure additional grafana data sources (passed through tpl)
     ## ref: http://docs.grafana.org/administration/provisioning/#datasources

--- a/charts/mongo-data-connector/Chart.yaml
+++ b/charts/mongo-data-connector/Chart.yaml
@@ -17,8 +17,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.29.0
+appVersion: 2.30.0

--- a/charts/mongo-data-connector/values.yaml
+++ b/charts/mongo-data-connector/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 ##
 image:
   repository: hasura/mongo-data-connector
-  tag: v2.29.0
+  tag: v2.30.0
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
- Update `hasura/graphql-engine:v2.30.0`  
- Update `hasura/graphql-data-connector:v2.30.0` 
- Update `hasura/mongo-data-connector:v2.30.0`
- Change Grafana Dashboard URLs to https://grafana.com/orgs/hasurahq/dashboards
- Update changelog action