### PR TITLE
feat: support SecretProviderClass for GraphQL Engine

### DIFF
--- a/charts/graphql-data-connector/.helmignore
+++ b/charts/graphql-data-connector/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+values.override.yaml

--- a/charts/graphql-data-connector/values.yaml
+++ b/charts/graphql-data-connector/values.yaml
@@ -112,7 +112,7 @@ nodeSelector: {}
 ## Tolerations for use with node taints
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: {}
+tolerations: []
 
 ## Define privilege and access control settings for a Pod or Container
 ##
@@ -186,7 +186,7 @@ resources: {}
 
 ## Additional environment variables for the deployment
 ##
-extraEnvs: {}
+extraEnvs: []
 
 ## Service configuration for graphql-data-connector service
 ##

--- a/charts/graphql-engine/.helmignore
+++ b/charts/graphql-engine/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+values.override.yaml

--- a/charts/graphql-engine/examples/08-secret-provider-class.yaml
+++ b/charts/graphql-engine/examples/08-secret-provider-class.yaml
@@ -1,0 +1,58 @@
+# secrets are still created if postgres is enable
+# if you use external postgres server, you should disable it
+postgres:
+  enabled: true
+
+  auth:
+    username: hasura
+    password: postgrespassword
+    database: hasura
+
+  persistence:
+    enabled: true
+    size: 10Gi
+
+# disable auto-generated secrets because this deployment use secret provider class
+secret:
+  enabled: false
+
+# you also need to define env variables manually that reference to the secret provider volume
+extraEnvs:
+  - name: HASURA_GRAPHQL_ADMIN_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: kvsecret
+        key: admin-secret
+
+secretProviderClass:
+  enabled: true
+
+  provider: "vault"
+
+  secretObjects:
+    - secretName: kvsecret
+      type: Opaque
+      labels:
+        environment: "test"
+      data:
+        - objectName: secret-1
+          key: admin-secret
+        - objectName: secret-2
+          key: username
+        - objectName: secret-3
+          key: username_b64
+
+  parameters:
+    roleName: "kv-role"
+    vaultAddress: "http://vault.vault:8200"
+    objects: |
+      - objectName: "secret-1"
+        secretPath: "/v1/secret/data/kv-sync1"
+        secretKey: "bar1"
+      - objectName: "secret-2"
+        secretPath: "v1/secret/data/kv-sync2"
+        secretKey: "bar2"
+      - objectName: "secret-3"
+        secretPath: "/v1/secret/data/kv-sync3"
+        secretKey: "bar3"
+        encoding: "base64"

--- a/charts/graphql-engine/templates/deployment.yaml
+++ b/charts/graphql-engine/templates/deployment.yaml
@@ -82,9 +82,16 @@ spec:
           livenessProbe:
             {{- toYaml .Values.healthChecks.livenessProbe | nindent 12 }}
         {{- end }}
-        {{- if .Values.extraVolumeMounts }}
+        {{- if or .Values.extraVolumeMounts (.Values.secretProviderClass).enabled }}
           volumeMounts:
+          {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+            {{- if (.Values.secretProviderClass).enabled }}
+            - name: secrets-store-inline
+              mountPath: "/mnt/secrets-store"
+              readOnly: true
+            {{- end }}
         {{- end }}
           env:
           {{- with .Values.config }}
@@ -166,6 +173,7 @@ spec:
                   name: {{ template "common.configMapName" $ }}
             {{- end }}
           {{- end }}
+          {{- if or (.Values.secret).enabled (.Values.postgres).enabled }}
           {{- if or (.Values.config).metadataOnly (.Values.secret).metadataDbUrl }}
             - name: HASURA_GRAPHQL_METADATA_DATABASE_URL
               valueFrom:
@@ -179,6 +187,8 @@ spec:
                   key: HASURA_GRAPHQL_DATABASE_URL
                   name: {{ template "common.secretsName" $ }}
           {{- end }}
+          {{- end }}
+          {{- if (.Values.secret).enabled }}
           {{- with .Values.secret }}
             {{- if .adminSecrets }}
             - name: HASURA_GRAPHQL_ADMIN_SECRETS
@@ -259,6 +269,7 @@ spec:
                   name: {{ template "common.secretsName" $ }}
             {{- end }}
           {{- end }}
+          {{- end }}
           {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -277,4 +288,13 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if (.Values.secretProviderClass).enabled }}
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ coalesce .Values.secretProviderClass.name (printf "%s-secret-provider" $appName) }}
     {{- end }}

--- a/charts/graphql-engine/templates/secretproviderclass.yaml
+++ b/charts/graphql-engine/templates/secretproviderclass.yaml
@@ -1,0 +1,21 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+{{- if (.Values.secretProviderClass).enabled -}}
+{{- $appName := include "common.name" . -}}
+{{- with .Values.secretProviderClass }}
+apiVersion: {{ coalesce .apiVersion "secrets-store.csi.x-k8s.io/v1" }}
+kind: SecretProviderClass
+metadata:
+  name: {{ coalesce .name (printf "%s-secret-provider" $appName) }}
+  namespace: {{ template "common.namespace" $ }}
+spec:
+  provider: {{ .provider }}
+  {{- if .secretObjects }}
+  secretObjects: 
+    {{- toYaml .secretObjects | nindent 4 }}
+  {{- end }}
+  parameters: 
+    {{- toYaml .parameters | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/graphql-engine/templates/secrets.yaml
+++ b/charts/graphql-engine/templates/secrets.yaml
@@ -2,7 +2,7 @@
 # Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 
 {{- with coalesce .Values.secret .Values.secrets }}
-{{- if .enabled }}
+{{- if or .enabled ($.Values.postgres).enabled }}
 {{ $hgeRedisUrl := tpl .redisUrl $ }}
 {{ $hgeRateLimitRedisUrl := tpl .rateLimitRedisUrl $ }}
 ---
@@ -21,6 +21,7 @@ data:
 {{- else }}
   HASURA_GRAPHQL_DATABASE_URL: {{ include "db.url" $ | b64enc | quote }}
 {{- end }}
+{{- if .enabled }}
   HASURA_GRAPHQL_ADMIN_SECRET: {{ .adminSecret | b64enc | quote }}
 {{- if .adminSecrets }}
   HASURA_GRAPHQL_ADMIN_SECRETS: {{ toRawJson .adminSecrets | b64enc | quote }}
@@ -50,6 +51,7 @@ data:
 {{- end }}
 {{- range $key, $value := (coalesce .extraSecrets .data) }}
   {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graphql-engine/values.yaml
+++ b/charts/graphql-engine/values.yaml
@@ -122,7 +122,7 @@ nodeSelector: {}
 ## Tolerations for use with node taints
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: {}
+tolerations: []
 
 ## Define privilege and access control settings for a Pod or Container
 ##
@@ -197,7 +197,7 @@ resources: {}
 ## Additional environment variables for the graphql-engine deployment
 ## Ref: https://hasura.io/docs/latest/deployment/graphql-engine-flags/reference/
 ##
-extraEnvs: {}
+extraEnvs: []
 
 ## Additional environment variables for the graphql-engine deployment, using templates
 ##
@@ -431,6 +431,31 @@ secret:
   ## These secrets will be mapped into both secret and container environment variables
   ##
   extraSecrets: {}
+
+secretProviderClass:
+  enabled: false
+
+  ## Specify your secret provider class name (optional)
+  ## @default: <Release namespace>-secret-provider
+  ##
+  name: ""
+
+  ## Specify a custom apiVersion if your cluster is using unstable versions
+  ##
+  apiVersion: ""
+
+  ## Specify a secret provider. Accepted provider options: azure or vault or gcp
+  ## https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation#install-external-secret-providers
+  ##
+  provider: "vault"
+
+  ## Defines the desired state of synced K8s secret objects
+  ##
+  secretObjects: []
+
+  ## Configure customer parameters for the target secret provider
+  ##
+  parameters: {}
 
 ## The main postgres database for metadata and data source connection
 ## Disable the service if you use external Postgres clusters

--- a/charts/hasura-enterprise-stack/.helmignore
+++ b/charts/hasura-enterprise-stack/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+values.override.yaml

--- a/charts/mongo-data-connector/.helmignore
+++ b/charts/mongo-data-connector/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+values.override.yaml

--- a/charts/mongo-data-connector/values.yaml
+++ b/charts/mongo-data-connector/values.yaml
@@ -111,7 +111,7 @@ nodeSelector: {}
 ## Tolerations for use with node taints
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: {}
+tolerations: []
 
 ## Define privilege and access control settings for a Pod or Container
 ##
@@ -185,7 +185,7 @@ resources: {}
 
 ## Additional environment variables for the deployment
 ##
-extraEnvs: {}
+extraEnvs: []
 
 ## Service configuration for mongo-data-connector service
 ##

--- a/charts/postgres/.helmignore
+++ b/charts/postgres/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+values.override.yaml

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -132,7 +132,7 @@ nodeSelector: {}
 ## Tolerations for use with node taints
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: {}
+tolerations: []
 
 ## Define privilege and access control settings for a Pod or Container
 ##


### PR DESCRIPTION
The PR supports [Secrets Store CSI](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/getting-started) for GraphQL Engine. The Secrets Store CSI Driver allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores (GCP, AWS, Azure, Vault) into their pods as a volume.

You can look at the configuration example [here](https://github.com/hasura/helm-charts/blob/feat/support-secret-provider-class/charts/graphql-engine/examples/08-secret-provider-class.yaml)

**Note**: to use these secret stores you need to disable auto-generated secrets and configure env variables yourself.

Manifest: [graphql-engine-0.1.1.tar.gz](https://github.com/hasura/helm-charts/files/12560462/graphql-engine-0.1.1.tar.gz)
