### PR TITLE
Add service account template to `graphql-engine`

### DIFF
--- a/charts/graphql-engine/templates/serviceaccount.yaml
+++ b/charts/graphql-engine/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- $namespace := include "common.namespace" . -}}
+
+{{- if .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default "graphql-engine" }}
+  namespace: {{ $namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.labels }}
+  labels:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+{{  end  }}

--- a/charts/graphql-engine/values.yaml
+++ b/charts/graphql-engine/values.yaml
@@ -95,7 +95,7 @@ healthChecks:
 ##
 serviceAccount:
   enabled: false
-  name: ""
+  name: graphql-engine
   annotations: {}
   labels: {}
 

--- a/charts/graphql-engine/values.yaml
+++ b/charts/graphql-engine/values.yaml
@@ -96,6 +96,8 @@ healthChecks:
 serviceAccount:
   enabled: false
   name: ""
+  annotations: {}
+  labels: {}
 
 ## Additional annotations
 ##


### PR DESCRIPTION
Adds a service account template for the `graphql-engine` chart. This template will be rendered (default name: `graphql-engine`) when `serviceAccount.enabled` is set to `true`, also allows adding desired `annotations` or `labels` to the service account. 

Fixes https://github.com/hasura/helm-charts/issues/18 