### PR TITLE
feat: support envFrom and extraVolumes

### DIFF
--- a/charts/graphql-data-connector/Chart.yaml
+++ b/charts/graphql-data-connector/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.46.0
+appVersion: 2.48.3

--- a/charts/graphql-data-connector/README.md
+++ b/charts/graphql-data-connector/README.md
@@ -52,6 +52,7 @@ See [helm install](https://helm.sh/docs/helm/helm_install/) for command document
 | `extraVolumes`                                    | Optionally specify extra list of additional volumes for the GraphQL Data Connector pod                     | `[]`                            |
 | `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the GraphQL Data Connector container          | `[]`                            |
 | `extraEnvs`                                       | Optionally specify extra list of additional environment variables for the pod                              | `[]`                            |
+| `envFrom`                                         | Allows you to set environment variables for a container by referencing either a ConfigMap or a Secret      | `[]`                            |
 | `resources`                                       | Resource requests and limits of GraphQL Data Connector container                                           | `{}`                            |
 | `serviceAccount.enabled`                          | Enable ServiceAccount for GraphQL Data Connector pod                                                       | `false`                         |
 | `serviceAccount.name`                             | The name of the ServiceAccount to use                                                                      | `""`                            |

--- a/charts/graphql-data-connector/templates/deployment.yaml
+++ b/charts/graphql-data-connector/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -104,4 +108,8 @@ spec:
     {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
     {{- end }}

--- a/charts/graphql-data-connector/values.yaml
+++ b/charts/graphql-data-connector/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 ##
 image:
   repository: hasura/graphql-data-connector
-  tag: v2.46.0
+  tag: v2.48.3
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -131,6 +131,10 @@ initContainers: []
 ##
 extraContainers: []
 
+## Optionally specify extra list of additional volumes for the pod
+##
+extraVolumes: []
+
 ## Extra volume mounts
 ##
 extraVolumeMounts: []
@@ -188,6 +192,12 @@ autoscaling:
 ##   cpu: "1"
 ##
 resources: {}
+
+## Allows you to set environment variables for a container by referencing either a ConfigMap or a Secret. 
+## When you use envFrom, all the key-value pairs in the referenced ConfigMap or Secret are set as environment variables for the container. 
+## You can also specify a common prefix string.
+##
+envFrom: []
 
 ## Additional environment variables for the deployment
 ##

--- a/charts/graphql-engine/Chart.yaml
+++ b/charts/graphql-engine/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.46.0
+appVersion: 2.48.3
 
 dependencies:
   - name: postgres

--- a/charts/graphql-engine/README.md
+++ b/charts/graphql-engine/README.md
@@ -77,6 +77,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command docu
 | `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the GraphQL Data Connector container         | `[]`                    |
 | `extraEnvs`                                       | Optionally specify extra list of additional environment variables for the pod                             | `[]`                    |
 | `extraEnvsTpl`                                    | Optionally specify extra list of additional environment variables for the pod, using text template        | `""`                    |
+| `envFrom`                                         | Allows you to set environment variables for a container by referencing either a ConfigMap or a Secret     | `[]`                    |
 | `resources`                                       | Resource requests and limits of GraphQL Data Connector container                                          | `{}`                    |
 | `serviceAccount.enabled`                          | Enable ServiceAccount for GraphQL Data Connector pod                                                      | `false`                 |
 | `serviceAccount.name`                             | The name of the ServiceAccount to use                                                                     | `""`                    |

--- a/charts/graphql-engine/templates/deployment.yaml
+++ b/charts/graphql-engine/templates/deployment.yaml
@@ -279,6 +279,10 @@ spec:
           {{- if .Values.extraEnvsTpl }}
             {{- tpl .Values.extraEnvsTpl $ | nindent 12 }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           
         {{- if .Values.resources }}
           resources:

--- a/charts/graphql-engine/values.yaml
+++ b/charts/graphql-engine/values.yaml
@@ -39,7 +39,7 @@ labels: {}
 ##
 image:
   repository: hasura/graphql-engine
-  tag: v2.46.0
+  tag: v2.48.3
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -139,7 +139,7 @@ initContainers: []
 ##
 extraContainers: []
 
-## Optionally specify extra list of additional volumes for the PostgreSQL pod
+## Optionally specify extra list of additional volumes for the pod
 ##
 extraVolumes: []
 
@@ -209,6 +209,12 @@ extraEnvs: []
 ## Additional environment variables for the graphql-engine deployment, using templates
 ##
 extraEnvsTpl: ""
+
+## Allows you to set environment variables for a container by referencing either a ConfigMap or a Secret. 
+## When you use envFrom, all the key-value pairs in the referenced ConfigMap or Secret are set as environment variables for the container. 
+## You can also specify a common prefix string.
+##
+envFrom: []
 
 ## Service configuration for graphql-engine service
 ##

--- a/charts/hasura-enterprise-stack/Chart.yaml
+++ b/charts/hasura-enterprise-stack/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.46.0
+appVersion: 2.48.3
 
 dependencies:
   - name: graphql-engine

--- a/charts/mongo-data-connector/Chart.yaml
+++ b/charts/mongo-data-connector/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.46.0
+appVersion: 2.48.3

--- a/charts/mongo-data-connector/README.md
+++ b/charts/mongo-data-connector/README.md
@@ -26,51 +26,52 @@ See [helm install](https://helm.sh/docs/helm/helm_install/) for command document
 
 ## Parameters
 
-| Name                                              | Description                                                                                     | Value                         |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- |
-| `global.imageRegistry`                            | Global Docker image registry                                                                    | `""`                          |
-| `global.imagePullSecrets`                         | Global Docker registry secret names as an array                                                 | `[]`                          |
-| `global.prefixOverride`                           | Override the naming prefix instead of the release name                                          | `{{ .Release.Name }}`         |
-| `nameOverride`                                    | String to override the deployment name                                                          | `""`                          |
-| `namespaceOverride`                               | String to override the namespace                                                                | `""`                          |
-| `labels`                                          | Add labels to the deployment resource                                                           | `{}`                          |
-| `annotations`                                     | Add annotations to the deployment resource                                                      | `{}`                          |
-| `command`                                         | Customize the execution command                                                                 | `[]`                          |
-| `args`                                            | Customize execution arguments                                                                   | `[]`                          |
-| `replicas`                                        | Number of pod replicas                                                                          | `1`                           |
-| `image.registry`                                  | Mongo Data Connector image registry                                                             | `docker.io`                   |
-| `image.repository`                                | Mongo Data Connector image repository                                                           | `hasura/mongo-data-connector` |
-| `image.tag`                                       | Mongo Data Connector image tag                                                                  | `v2.29.0`                     |
-| `image.pullPolicy`                                | Mongo Data Connector image pull policy                                                          | `IfNotPresent`                |
-| `image.pullSecrets`                               | Specify image pull secrets                                                                      | `[]`                          |
-| `affinity`                                        | Affinity for Mongo Data Connector pod assignment                                                | `{}`                          |
-| `nodeSelector`                                    | Node labels for Mongo Data Connector pod assignment                                             | `{}`                          |
-| `tolerations`                                     | Tolerations for Mongo Data Connector pod assignment                                             | `{}`                          |
-| `securityContext`                                 | Define privilege and access control settings for a Pod or Container                             | `{}`                          |
-| `initContainers`                                  | Additional initialization containers                                                            | `[]`                          |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the Mongo Data Connector pod         | `[]`                          |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the Mongo Data Connector pod            | `[]`                          |
-| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the Mongo Data Connector container | `[]`                          |
-| `extraEnvs`                                       | Optionally specify extra list of additional environment variables for the pod                   | `[]`                          |
-| `resources`                                       | Resource requests and limits of Mongo Data Connector container                                  | `{}`                          |
-| `serviceAccount.enabled`                          | Enable ServiceAccount for Mongo Data Connector pod                                              | `false`                       |
-| `serviceAccount.name`                             | The name of the ServiceAccount to use                                                           | `""`                          |
-| `service.type`                                    | Kubernetes Service type of Mongo Data Connector                                                 | `ClusterIP`                   |
-| `service.labels`                                  | Optionally specify labels for Mongo Data Connector Service                                      | `{}`                          |
-| `service.annotations`                             | Optionally specify annotations for Mongo Data Connector Service                                 | `{}`                          |
-| `healthChecks.enabled`                            | Enable health check for Mongo Data Connector container                                          | `true`                        |
-| `healthChecks.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                        | `5`                           |
-| `healthChecks.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                               | `10`                          |
-| `healthChecks.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                              | `5`                           |
-| `healthChecks.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                            | `5`                           |
-| `healthChecks.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                            | `1`                           |
-| `healthChecks.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                         | `30`                          |
-| `healthChecks.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                | `10`                          |
-| `healthChecks.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                               | `5`                           |
-| `healthChecks.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                             | `5`                           |
-| `healthChecks.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                             | `1`                           |
-| `autoscaling.enabled`                             | Enable autoscaling configuration for the deployment                                             | `false`                       |
-| `autoscaling.minReplicas`                         | Minimum number of replicas that the deployment can be scaled                                    | `1`                           |
-| `autoscaling.maxReplicas`                         | Maximum number of replicas that the deployment can be scaled                                    | `2`                           |
-| `autoscaling.behavior`                            | Configure separate scale-up and scale-down behaviors                                            | `{}`                          |
-| `autoscaling.metrics`                             | Configure autoscaling policies based on metrics                                                 | `{}`                          |
+| Name                                              | Description                                                                                           | Value                         |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `global.imageRegistry`                            | Global Docker image registry                                                                          | `""`                          |
+| `global.imagePullSecrets`                         | Global Docker registry secret names as an array                                                       | `[]`                          |
+| `global.prefixOverride`                           | Override the naming prefix instead of the release name                                                | `{{ .Release.Name }}`         |
+| `nameOverride`                                    | String to override the deployment name                                                                | `""`                          |
+| `namespaceOverride`                               | String to override the namespace                                                                      | `""`                          |
+| `labels`                                          | Add labels to the deployment resource                                                                 | `{}`                          |
+| `annotations`                                     | Add annotations to the deployment resource                                                            | `{}`                          |
+| `command`                                         | Customize the execution command                                                                       | `[]`                          |
+| `args`                                            | Customize execution arguments                                                                         | `[]`                          |
+| `replicas`                                        | Number of pod replicas                                                                                | `1`                           |
+| `image.registry`                                  | Mongo Data Connector image registry                                                                   | `docker.io`                   |
+| `image.repository`                                | Mongo Data Connector image repository                                                                 | `hasura/mongo-data-connector` |
+| `image.tag`                                       | Mongo Data Connector image tag                                                                        | `v2.29.0`                     |
+| `image.pullPolicy`                                | Mongo Data Connector image pull policy                                                                | `IfNotPresent`                |
+| `image.pullSecrets`                               | Specify image pull secrets                                                                            | `[]`                          |
+| `affinity`                                        | Affinity for Mongo Data Connector pod assignment                                                      | `{}`                          |
+| `nodeSelector`                                    | Node labels for Mongo Data Connector pod assignment                                                   | `{}`                          |
+| `tolerations`                                     | Tolerations for Mongo Data Connector pod assignment                                                   | `{}`                          |
+| `securityContext`                                 | Define privilege and access control settings for a Pod or Container                                   | `{}`                          |
+| `initContainers`                                  | Additional initialization containers                                                                  | `[]`                          |
+| `extraContainers`                                 | Optionally specify extra list of additional containers for the Mongo Data Connector pod               | `[]`                          |
+| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the Mongo Data Connector pod                  | `[]`                          |
+| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the Mongo Data Connector container       | `[]`                          |
+| `extraEnvs`                                       | Optionally specify extra list of additional environment variables for the pod                         | `[]`                          |
+| `envFrom`                                         | Allows you to set environment variables for a container by referencing either a ConfigMap or a Secret | `[]`                          |
+| `resources`                                       | Resource requests and limits of Mongo Data Connector container                                        | `{}`                          |
+| `serviceAccount.enabled`                          | Enable ServiceAccount for Mongo Data Connector pod                                                    | `false`                       |
+| `serviceAccount.name`                             | The name of the ServiceAccount to use                                                                 | `""`                          |
+| `service.type`                                    | Kubernetes Service type of Mongo Data Connector                                                       | `ClusterIP`                   |
+| `service.labels`                                  | Optionally specify labels for Mongo Data Connector Service                                            | `{}`                          |
+| `service.annotations`                             | Optionally specify annotations for Mongo Data Connector Service                                       | `{}`                          |
+| `healthChecks.enabled`                            | Enable health check for Mongo Data Connector container                                                | `true`                        |
+| `healthChecks.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                              | `5`                           |
+| `healthChecks.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                     | `10`                          |
+| `healthChecks.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                    | `5`                           |
+| `healthChecks.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                  | `5`                           |
+| `healthChecks.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                  | `1`                           |
+| `healthChecks.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                               | `30`                          |
+| `healthChecks.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                      | `10`                          |
+| `healthChecks.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                     | `5`                           |
+| `healthChecks.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                   | `5`                           |
+| `healthChecks.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                   | `1`                           |
+| `autoscaling.enabled`                             | Enable autoscaling configuration for the deployment                                                   | `false`                       |
+| `autoscaling.minReplicas`                         | Minimum number of replicas that the deployment can be scaled                                          | `1`                           |
+| `autoscaling.maxReplicas`                         | Maximum number of replicas that the deployment can be scaled                                          | `2`                           |
+| `autoscaling.behavior`                            | Configure separate scale-up and scale-down behaviors                                                  | `{}`                          |
+| `autoscaling.metrics`                             | Configure autoscaling policies based on metrics                                                       | `{}`                          |

--- a/charts/mongo-data-connector/templates/deployment.yaml
+++ b/charts/mongo-data-connector/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -104,4 +108,8 @@ spec:
     {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
     {{- end }}

--- a/charts/mongo-data-connector/values.yaml
+++ b/charts/mongo-data-connector/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 ##
 image:
   repository: hasura/mongo-data-connector
-  tag: v2.46.0
+  tag: v2.48.3
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -126,6 +126,10 @@ initContainers: []
 ##
 extraContainers: []
 
+## Optionally specify extra list of additional volumes for the pod
+##
+extraVolumes: []
+
 ## Extra volume mounts
 ##
 extraVolumeMounts: []
@@ -187,6 +191,12 @@ resources: {}
 ## Additional environment variables for the deployment
 ##
 extraEnvs: []
+
+## Allows you to set environment variables for a container by referencing either a ConfigMap or a Secret. 
+## When you use envFrom, all the key-value pairs in the referenced ConfigMap or Secret are set as environment variables for the container. 
+## You can also specify a common prefix string.
+##
+envFrom: []
 
 ## Service configuration for mongo-data-connector service
 ##


### PR DESCRIPTION
This pull request introduces several updates to Helm charts for various Hasura components, focusing on version upgrades, new configuration options, and enhancements to deployment templates. The most important changes include updating the application version, adding support for `envFrom` to reference environment variables from ConfigMaps or Secrets, and introducing additional volume configuration options.

### Version Upgrades:
* Updated `appVersion` from `2.46.0` to `2.48.3` in the following charts: `graphql-data-connector` (`[[1]](diffhunk://#diff-02c57c17f04f353745138dc7c6dae60523d0c683f703b609c6959df1ca21818eL24-R24)`), `graphql-engine` (`[[2]](diffhunk://#diff-e33199ab2fca34887572b559a3cee39e59165e1eb4104d14f16172546fd3bd2aL24-R24)`), `hasura-enterprise-stack` (`[[3]](diffhunk://#diff-52dafd941b2f33df7cbfcd227cfcba8c091b61ff05f9ceca988441ae99964ae8L24-R24)`), and `mongo-data-connector` (`[[4]](diffhunk://#diff-7721bcb024115f30bab22d82824d70400c6c8580280ae2066a24d19ad1c77a62L24-R24)`).

### New Configuration Options:
* Added `envFrom` support to allow setting environment variables for containers by referencing ConfigMaps or Secrets. This change is reflected in the following:
  - `README.md` files for `graphql-data-connector` (`[[1]](diffhunk://#diff-39b9db57eac48a462e4073b99daed2f340d94d79803a94c58dc8f269602ec855R55)`), `graphql-engine` (`[[2]](diffhunk://#diff-27828967698afdf0f6102494e2d50f9461f33ab0bda07cc8a167ba876e00d0b7R80)`), and `mongo-data-connector` (`[[3]](diffhunk://#diff-e8909b1953db9fcbfab850a6da4768efdd2067896a8826c2344ee9c8a264065cR55)`).
  - Deployment templates for `graphql-data-connector` (`[[1]](diffhunk://#diff-269865c30c07416f45707b9466fcc587928d7a39cce25015ab1ccbc42c462a06R92-R95)`), `graphql-engine` (`[[2]](diffhunk://#diff-ddd3a3a6997eb0826448069907a5736e7b91bd888245b6f2d8bf5aabbdd295a4R282-R285)`), and `mongo-data-connector` (`[[3]](diffhunk://#diff-6a403e7a6f8e86d1eed5053054e7061eee8fbd8d2dd69255b7874bf60dc7ddb9R92-R95)`).
  - `values.yaml` files for `graphql-data-connector` (`[[1]](diffhunk://#diff-b1590e56b597751ceb9de99ad227d26cd288307235d3db63b1062b1aa48fc705R196-R201)`), `graphql-engine` (`[[2]](diffhunk://#diff-b18b9011a0ba9b3f7c3991babf8d203d952661cf228b67131d5df5f788babdd2R213-R218)`), and `mongo-data-connector` (`[[3]](diffhunk://#diff-30f17845b98e30f0f61c90bfd72616fc3520af5ba1b01c44b159f611f61ed284R195-R200)`).

### Volume Configuration Enhancements:
* Introduced `extraVolumes` to specify additional volumes for pods:
  - Deployment templates for `graphql-data-connector` (`[[1]](diffhunk://#diff-269865c30c07416f45707b9466fcc587928d7a39cce25015ab1ccbc42c462a06R112-R115)`) and `mongo-data-connector` (`[[2]](diffhunk://#diff-6a403e7a6f8e86d1eed5053054e7061eee8fbd8d2dd69255b7874bf60dc7ddb9R112-R115)`).
  - `values.yaml` files for `graphql-data-connector` (`[[1]](diffhunk://#diff-b1590e56b597751ceb9de99ad227d26cd288307235d3db63b1062b1aa48fc705R134-R137)`) and `mongo-data-connector` (`[[2]](diffhunk://#diff-30f17845b98e30f0f61c90bfd72616fc3520af5ba1b01c44b159f611f61ed284R129-R132)`).

These changes improve flexibility in configuring deployments, making it easier to manage environment variables and volume configurations across different components.