### PR TITLE
Release v0.9.1

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -24,9 +24,9 @@ jobs:
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,14 +20,14 @@ jobs:
       modified-charts-files: ${{ steps.list-changed-charts.outputs.all_modified_files }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
       - name: Get list of changed charts
         id: list-changed-charts
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           base_sha: ${{ github.event.inputs.base-branch }}
           files: charts/*/Chart.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
@@ -106,7 +106,7 @@ jobs:
           done
 
       - name: Stash generated charts changelog files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: charts-generated-changelog
           path: |
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
@@ -152,44 +152,3 @@ jobs:
         uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-  commit-charts-changelog:
-    needs:
-      - find-charts-to-release
-      - release-charts
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.branch }}
-
-      - name: Unstash generated charts changelog files
-        uses: actions/download-artifact@v4
-        with:
-          name: charts-generated-changelog
-          path: charts
-
-      - name: Commit charts CHANGELOG.md file
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-          released_charts_files="${{ needs.find-charts-to-release.outputs.modified-charts-files }}"
-          echo "released_charts_files: ${released_charts_files}"
-
-          # Commit changes locally.
-          chart_names=""
-          for chart_file in ${released_charts_files}; do
-              chart_name=$(grep -Po "(?<=^name: ).+" ${chart_file})
-              chart_version=$(grep -Po "(?<=^version: ).+" ${chart_file})
-              chart_path="charts/${chart_name}"
-
-              git add ${chart_path}/CHANGELOG.md
-              chart_names="${chart_names} ${chart_name}:${chart_version}"
-          done
-
-          git commit -m "Update CHANGELOG for charts ${chart_names}"
-          # Push changes to the main branch.
-          git push origin main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hasura Helm Charts
 
-This repository contains Helm charts to help with the deployment of Hasura GraphQL on Kubernetes. This project is currently in active development.
+This repository contains Helm charts to help with the deployment of Hasura GraphQL Engine v2 on Kubernetes. This project is currently in active development.
 
 ## Repository
 

--- a/charts/graphql-data-connector/CHANGELOG.md
+++ b/charts/graphql-data-connector/CHANGELOG.md
@@ -1,6 +1,10 @@
 The changelog is automatically generated using [git-chglog](https://github.com/git-chglog/git-chglog) and it follows [Keep a Changelog](https://keepachangelog.com) format.
 
 
+<a name="graphql-data-connector@0.9.1"></a>
+## [graphql-data-connector@0.9.1] - 2025-10-29
+- feat: update hasura dependencies to v2.48.6
+  
 <a name="graphql-data-connector@0.9.0"></a>
 ## [graphql-data-connector@0.9.0] - 2025-07-28
 - feat: update hasura dependencies to v2.48.3

--- a/charts/graphql-data-connector/Chart.yaml
+++ b/charts/graphql-data-connector/Chart.yaml
@@ -17,8 +17,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.48.3
+appVersion: 2.48.6

--- a/charts/graphql-data-connector/values.yaml
+++ b/charts/graphql-data-connector/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 ##
 image:
   repository: hasura/graphql-data-connector
-  tag: v2.48.3
+  tag: v2.48.6
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/charts/graphql-engine/CHANGELOG.md
+++ b/charts/graphql-engine/CHANGELOG.md
@@ -1,6 +1,11 @@
 The changelog is automatically generated using [git-chglog](https://github.com/git-chglog/git-chglog) and it follows [Keep a Changelog](https://keepachangelog.com) format.
 
 
+<a name="graphql-engine@0.9.1"></a>
+## [graphql-engine@0.9.1] - 2025-10-29
+- feat: update hasura dependencies to v2.48.6
+- fix: handle false value for enableConsole in ConfigMap
+  
 <a name="graphql-engine@0.9.0"></a>
 ## [graphql-engine@0.9.0] - 2025-07-28
 - feat: update hasura dependencies to v2.48.3

--- a/charts/graphql-engine/Chart.yaml
+++ b/charts/graphql-engine/Chart.yaml
@@ -17,11 +17,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.48.3
+appVersion: 2.48.6
 
 dependencies:
   - name: postgres

--- a/charts/graphql-engine/README.md
+++ b/charts/graphql-engine/README.md
@@ -136,22 +136,22 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command docu
 
 ### Secret parameters
 
-| Name                   | Description                                                                          | Value                                        |
-| ---------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------- |
-| `secret.enabled`       | Automatically generate a secret resource                                             | `true`                                       |
-| `secret.name`          | Optionally specify your secret name                                                  | `{{ .Release.Name }}-graphql-engine-secrets` |
-| `secret.eeLicenseKey`  | String to enable the Enterprise Edition with the license key (EE)                    | `""`                                         |
-| `secret.proKey`        | String to enable the Enterprise Classic edition (EE)                                 | `""`                                         |
-| `secret.metadataDbUrl` | The connection string to the metadata database                                       | `""`                                         |
-| `secret.adminSecret`   | The admin secret of GraphQL Engine                                                   | `""`                                         |
-| `secret.adminSecrets`  | Optionally specify a list of admin secrets (EE)                                      | `[]`                                         |
-| `secret.metricsSecret` | Prometheus metrics secret (EE)                                                       | `""`                                         |
-| `secret.jwtSecret`     | Specify the secret to enables Authentication using JWT                               | `""`                                         |
-| `secret.jwtSecrets`    | Optionally specify a list of secrets to enables Authentication using JWT (EE)        | `""`                                         |
-| `secret.redisUrl`      | The connection string to the redis database for caching (EE)                         | `""`                                         |
-| `secret.redisUrl`      | The connection string to the redis database for rate limit (EE)                      | `""`                                         |
-| `secret.ssoProviders`  | Optionally specify the list of Identity provider settings for console SSO login (EE) | `[]`                                         |
-| `secret.extraSecrets`  | Extra secrets data for graphql-engine environment variables (EE)                     | `{}`                                         |
+| Name                       | Description                                                                          | Value                                        |
+| -------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------- |
+| `secret.enabled`           | Automatically generate a secret resource                                             | `true`                                       |
+| `secret.name`              | Optionally specify your secret name                                                  | `{{ .Release.Name }}-graphql-engine-secrets` |
+| `secret.eeLicenseKey`      | String to enable the Enterprise Edition with the license key (EE)                    | `""`                                         |
+| `secret.proKey`            | String to enable the Enterprise Classic edition (EE)                                 | `""`                                         |
+| `secret.metadataDbUrl`     | The connection string to the metadata database                                       | `""`                                         |
+| `secret.adminSecret`       | The admin secret of GraphQL Engine                                                   | `""`                                         |
+| `secret.adminSecrets`      | Optionally specify a list of admin secrets (EE)                                      | `[]`                                         |
+| `secret.metricsSecret`     | Prometheus metrics secret (EE)                                                       | `""`                                         |
+| `secret.jwtSecret`         | Specify the secret to enables Authentication using JWT                               | `""`                                         |
+| `secret.jwtSecrets`        | Optionally specify a list of secrets to enables Authentication using JWT (EE)        | `""`                                         |
+| `secret.redisUrl`          | The connection string to the redis database for caching (EE)                         | `""`                                         |
+| `secret.rateLimitRedisUrl` | The connection string to the redis database for rate limit (EE)                      | `""`                                         |
+| `secret.ssoProviders`      | Optionally specify the list of Identity provider settings for console SSO login (EE) | `[]`                                         |
+| `secret.extraSecrets`      | Extra secrets data for graphql-engine environment variables (EE)                     | `{}`                                         |
 
 ### Postgres parameters
 

--- a/charts/graphql-engine/values.yaml
+++ b/charts/graphql-engine/values.yaml
@@ -39,7 +39,7 @@ labels: {}
 ##
 image:
   repository: hasura/graphql-engine
-  tag: v2.48.3
+  tag: v2.48.6
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/charts/hasura-enterprise-stack/CHANGELOG.md
+++ b/charts/hasura-enterprise-stack/CHANGELOG.md
@@ -1,5 +1,10 @@
 The changelog is automatically generated using [git-chglog](https://github.com/git-chglog/git-chglog) and it follows [Keep a Changelog](https://keepachangelog.com) format.
 
+<a name="hasura-enterprise-stack@0.9.1"></a>
+## [hasura-enterprise-stack@0.9.1] - 2025-10-29
+- feat: update hasura dependencies to v2.48.6
+- fix: change the Redis image registry from Binami to the official Redis. The Bitnami team deleted all old images so the current image tag will fail to pull.
+  
 <a name="hasura-enterprise-stack@0.9.0"></a>
 ## [hasura-enterprise-stack@0.9.0] - 2025-07-28
 - feat: update hasura dependencies to v2.48.3

--- a/charts/hasura-enterprise-stack/Chart.lock
+++ b/charts/hasura-enterprise-stack/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: graphql-engine
   repository: file://../graphql-engine
-  version: 0.9.0
+  version: 0.9.1
 - name: graphql-data-connector
   repository: file://../graphql-data-connector
-  version: 0.9.0
+  version: 0.9.1
 - name: mongo-data-connector
   repository: file://../mongo-data-connector
-  version: 0.9.0
+  version: 0.9.1
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.15.2
@@ -20,5 +20,5 @@ dependencies:
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
   version: 2.1.0
-digest: sha256:18e966bc1c265bf15519fd2f54167758c9e59bd6a5590b532418840837d3c5ee
-generated: "2025-07-28T22:30:45.217471+07:00"
+digest: sha256:c403466ad21fa9b5e7581072d84f9b815284b509d7c46b5003a3dfbc4909196e
+generated: "2025-10-29T00:27:03.658600677+07:00"

--- a/charts/hasura-enterprise-stack/Chart.yaml
+++ b/charts/hasura-enterprise-stack/Chart.yaml
@@ -17,23 +17,23 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.48.3
+appVersion: 2.48.6
 
 dependencies:
   - name: graphql-engine
-    version: 0.9.0
+    version: 0.9.1
     repository: file://../graphql-engine
     condition: graphql-engine.enabled
   - name: graphql-data-connector
-    version: 0.9.0
+    version: 0.9.1
     repository: file://../graphql-data-connector
     condition: global.connector.graphql.enabled
   - name: mongo-data-connector
-    version: 0.9.0
+    version: 0.9.1
     repository: file://../mongo-data-connector
     condition: global.connector.mongo.enabled
   - name: redis

--- a/charts/hasura-enterprise-stack/values.yaml
+++ b/charts/hasura-enterprise-stack/values.yaml
@@ -59,7 +59,11 @@ mongo-data-connector: {}
 ## Enable redis for GraphQL Engine's cache and rate limit
 ## see full values at https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
 ##
-redis: {}
+redis:
+  image:
+    registry: docker.io
+    repository: redis
+    tag: 7.2
 
 ## Dex is a middleware identity service for SSO login on console
 ## It is required if you want to connect with special authorization protocol ush as SAML, LDAP

--- a/charts/mongo-data-connector/CHANGELOG.md
+++ b/charts/mongo-data-connector/CHANGELOG.md
@@ -1,6 +1,10 @@
 The changelog is automatically generated using [git-chglog](https://github.com/git-chglog/git-chglog) and it follows [Keep a Changelog](https://keepachangelog.com) format.
 
 
+<a name="mongo-data-connector@0.9.1"></a>
+## [mongo-data-connector@0.9.1] - 2025-10-29
+- feat: update hasura dependencies to v2.48.6
+  
 <a name="mongo-data-connector@0.9.0"></a>
 ## [mongo-data-connector@0.9.0] - 2025-07-28
 - feat: update hasura dependencies to v2.48.3

--- a/charts/mongo-data-connector/Chart.yaml
+++ b/charts/mongo-data-connector/Chart.yaml
@@ -17,8 +17,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.48.3
+appVersion: 2.48.6

--- a/charts/mongo-data-connector/values.yaml
+++ b/charts/mongo-data-connector/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 ##
 image:
   repository: hasura/mongo-data-connector
-  tag: v2.48.3
+  tag: v2.48.6
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
This pull request updates all Hasura Helm charts and related workflows to use Hasura v2.48.6, improves workflow reliability by upgrading GitHub Actions and dependencies, and addresses issues with Redis image sourcing. It also fixes documentation and configuration issues for chart secrets and console settings.

**Chart dependency and image updates:**

* Upgraded Hasura dependencies (`appVersion` and image tags) to v2.48.6 in `graphql-engine`, `graphql-data-connector`, `mongo-data-connector`, and `hasura-enterprise-stack` charts. All chart versions bumped to 0.9.1. [[1]](diffhunk://#diff-02c57c17f04f353745138dc7c6dae60523d0c683f703b609c6959df1ca21818eL20-R24) [[2]](diffhunk://#diff-b1590e56b597751ceb9de99ad227d26cd288307235d3db63b1062b1aa48fc705L30-R30) [[3]](diffhunk://#diff-e33199ab2fca34887572b559a3cee39e59165e1eb4104d14f16172546fd3bd2aL20-R24) [[4]](diffhunk://#diff-b18b9011a0ba9b3f7c3991babf8d203d952661cf228b67131d5df5f788babdd2L42-R42) [[5]](diffhunk://#diff-52dafd941b2f33df7cbfcd227cfcba8c091b61ff05f9ceca988441ae99964ae8L20-R36) [[6]](diffhunk://#diff-7721bcb024115f30bab22d82824d70400c6c8580280ae2066a24d19ad1c77a62L20-R24) [[7]](diffhunk://#diff-30f17845b98e30f0f61c90bfd72616fc3520af5ba1b01c44b159f611f61ed284L30-R30)
* Updated `hasura-enterprise-stack` to use the official Redis image (instead of Bitnami) to avoid pull failures due to deleted Bitnami images. [[1]](diffhunk://#diff-d6e7845a849d840446114da73ffc727c9624b8d881190445ad8ddf12a4618967L62-R66) [[2]](diffhunk://#diff-f8fcdf9d4d57bd706b2a8eaee47df75cbabcd5ef79f858199404805e90821e5dR3-R7)

**GitHub Actions and workflow improvements:**

* Upgraded `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, and `actions/download-artifact` to their latest major versions in `.github/workflows/lint-test.yaml` and `.github/workflows/release.yaml`. [[1]](diffhunk://#diff-8ee75a42ccdffb28e750aba529bb689756d1773f5b5052e1ffea9486cf5fb2b7L15-R15) [[2]](diffhunk://#diff-8ee75a42ccdffb28e750aba529bb689756d1773f5b5052e1ffea9486cf5fb2b7L27-R29) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL23-R30) [[4]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL41-R41) [[5]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL109-R109) [[6]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL126-R126)
* Updated `tj-actions/changed-files` to v47 for improved reliability.
* Removed the `commit-charts-changelog` job from the release workflow, simplifying chart changelog management.

**Bug fixes and documentation improvements:**

* Fixed handling of `enableConsole: false` in the `graphql-engine` ConfigMap.
* Corrected secret parameter name in `graphql-engine` README from `redisUrl` to `rateLimitRedisUrl` for rate limiting.
* Improved README wording to clarify support for Hasura GraphQL Engine v2.

**Changelog updates:**

* Added changelog entries for version 0.9.1 in all charts, reflecting dependency upgrades and fixes. [[1]](diffhunk://#diff-63062c92fda726bec17addcce614ded1b236d5eb681b02ead3aa0e0f58ce0b17R4-R8) [[2]](diffhunk://#diff-9dd6a214dd71f502c315fc88f23e7b6a722141cc11d41e3aa58842894deb2673R4-R7) [[3]](diffhunk://#diff-f8fcdf9d4d57bd706b2a8eaee47df75cbabcd5ef79f858199404805e90821e5dR3-R7) [[4]](diffhunk://#diff-59b0c2d098aa73aa7278a584d1d80fe2784e7946e5d5de748c771cd8e3d1f866R4-R7)